### PR TITLE
bump up speedtest-cli version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM python:3.7-alpine
 MAINTAINER Dogukan Cagatay <dcagatay@gmail.com>
-RUN pip --no-cache-dir install speedtest-cli==2.1.2
+RUN pip --no-cache-dir install speedtest-cli==2.1.3
 ENTRYPOINT ["/usr/local/bin/speedtest-cli"]


### PR DESCRIPTION
in order to handle case where `ignoreids` is empty or contains empty
ids. See https://github.com/sivel/speedtest-cli/commit/cadc68b5aef20f28648072cf07a8f155639b81dd for details.

Signed-off-by: Andreas Schmid <service@aaschmid.de>